### PR TITLE
feat(add): Download latest version from official web

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,6 @@
+version: '3.8'
+x-project-name: koc
+
 volumes: 
   postgres-data: 
   redis-data: 
@@ -34,8 +37,9 @@ services:
       - server-data:/data 
  
     environment:
-      KOC_FORCE_SERVER_DOWNLOAD: true
-      KOC_SERVER_DONWLOAD_URL: https://chonky-delivery-network.akamaized.net/KnockoutCity-Server-10.0-269701.zip
+      KOC_FORCE_SERVER_DOWNLOAD: "true"
+      KOC_SERVER_DOWNLOAD_URL: https://chonky-delivery-network.akamaized.net/KnockoutCity-Server-10.0-269701.zip
+      KOC_SERVER_DOWNLOAD_LATEST_VERSION: "true" # This option will bypass the KOC_SERVER_DOWNLOAD_URL
 
       KOC_BACKEND_MAX_PLAYER_CONNECTIONS: 10
       KOC_SECRET:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ else
     echo "No Server Download Url provided. Can't download..."
     exit 1
   fi
-  if [[  "${KOC_SERVER_DOWNLOAD_LATEST_VERSION:-false}" == false ]]; then
+  if [[  "${KOC_SERVER_DOWNLOAD_LATEST_VERSION}" == false ]]; then
     echo 'Server is searching for the latest version...'
     LATEST_LINK=$(echo -n 'https://www.knockoutcity.com/private-server-edition' | grep -oP "https://chonky-delivery-network\.akamaized\.net/KnockoutCity-Server(.*).zip")
     if [[ -z "$LATEST_LINK" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,25 @@ KOC_SERVER_FILE_PATH=/data/KnockoutCityServer
 if [[ -d "$KOC_SERVER_FILE_PATH" && "${KOC_FORCE_SERVER_DOWNLOAD:-false}" == false ]]; then
   echo "Server files already downloaded. Skipping download..."
 else
-  if [[ -z "$KOC_SERVER_DONWLOAD_URL" ]]; then
+  if [[ -z "$KOC_SERVER_DOWNLOAD_URL" ]]; then
     echo "No Server Download Url provided. Can't download..."
     exit 1
+  fi
+  if [[  "${KOC_SERVER_DOWNLOAD_LATEST_VERSION:-false}" == false ]]; then
+    echo 'Server is searching for the latest version...'
+    LATEST_LINK=$(echo -n 'https://www.knockoutcity.com/private-server-edition' | grep -oP "https://chonky-delivery-network\.akamaized\.net/KnockoutCity-Server(.*).zip")
+    if [[ -z "$LATEST_LINK" ]]; then
+      echo "Coudln't find the latest version of Knockout City Server Edition. Going to download the URL in the yaml file"
+    else
+      echo "Found the latest version !"
+      KOC_SERVER_DOWNLOAD_URL=$LATEST_LINK
+    fi
   fi
 
   mkdir -p /data
   cd /data || exit 1
 
-  wget "$KOC_SERVER_DONWLOAD_URL" -O KnockoutCity-Server.zip
+  wget "$KOC_SERVER_DOWNLOAD_URL" -O KnockoutCity-Server.zip
   unzip KnockoutCity-Server.zip
   rm KnockoutCity-Server.zip
 fi


### PR DESCRIPTION
feat(add): Download latest version from official web
feat(fix): Boolean to string for `KOC_FORCE_SERVER_DOWNLOAD`
feat(fix): Typo from `KOC_SERVER_DONWLOAD_URL` to `KOC_SERVER_DOWNLOAD_URL`
------
This ability will download the latest version of the official web.
The option is described in the `compose.yml` at `KOC_SERVER_DOWNLOAD_LATEST_VERSION`

This PR also add a `x-project-name` to be set as `KOC` to have a prefix in each container

Also added version 3.8 in the compose.yml, so, if you want to remove it you can, but for me, having this version is perfect.

